### PR TITLE
8.3: Update to version 10.02.14.01-k

### DIFF
--- a/SOURCES/qlogic-qla2xxx-10.02.11.00_k.tar.gz
+++ b/SOURCES/qlogic-qla2xxx-10.02.11.00_k.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8304e52bb4e4fa77f70015133ec2169cd18147ae9ad9f94f232350546369f80a
-size 658194

--- a/SOURCES/qlogic-qla2xxx-10.02.14.01_k.tar.gz
+++ b/SOURCES/qlogic-qla2xxx-10.02.14.01_k.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:28b6e9ee2689fe63048fb2241df5dd9e7d4fd4e04c42a0682087bd9d570311af
+size 604710

--- a/SPECS/qlogic-qla2xxx-alt.spec
+++ b/SPECS/qlogic-qla2xxx-alt.spec
@@ -14,12 +14,12 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}-alt
-Version: 10.02.11.00_k
+Version: 10.02.14.01_k
 Release: 1%{?dist}
 License: GPL
 
-# Extracted from latest XS driver disk
-Source0: qlogic-qla2xxx-10.02.11.00_k.tar.gz
+# Source tarball from https://www.marvell.com/support/downloads.html
+Source0: qlogic-qla2xxx-10.02.14.01_k.tar.gz
 Patch0: fix-livepatching.patch
 
 BuildRequires: gcc
@@ -61,6 +61,9 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 /lib/modules/%{kernel_version}/*/*.ko
 
 %changelog
+* Thu Dec 11 2025 Thierry Escande <thierry.escande@vates.tech> - 10.02.14.01_k-1
+- Synced sources to version 10.02.14.01-k from marvell.com
+
 * Fri May 03 2024 Gael Duperrey <gduperrey@vates.tech> - 10.02.11.00_k-1
 - Update to version 10.02.11.00_k
 - Synced from XS driver SRPM qlogic-qla2xxx-10.02.11.00_k-1.xs8~2_1.src.rpm


### PR DESCRIPTION
The sources tarball was extracted from qlgc-qla2xxx-10.02.14.01_k-1.rhel9u6.src.rpm, downloaded from marvell.com.